### PR TITLE
More fixes for non-interactive ECR deployment

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,11 +1,11 @@
 name: core
 apiVersion: v1
-version: 2.2.3
+version: 2.2.5
 appVersion: 5.0.3
-description: Helm chart for NeuVector's core services
+description: Helm chart for NeuVector's core services on EKS
 home: https://neuvector.com
 icon: https://avatars2.githubusercontent.com/u/19367275?s=200&v=4
 maintainers:
-  - name: becitsthere
-    email: support@neuvector.com
+  - name: SUSE Public Cloud Engineering
+    email: public-cloud-users@susecloud.net
 engine: gotpl

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -4,8 +4,8 @@
 
 openshift: false
 
-registry: 709825985650.dkr.ecr.us-east-1.amazonaws.com/suse
-tag: latest
+registry: 709825985650.dkr.ecr.us-east-1.amazonaws.com
+tag: 5.0.3
 oem:
 imagePullSecrets:
 psp: false
@@ -22,8 +22,9 @@ controller:
       maxSurge: 1
       maxUnavailable: 0
   image:
-    repository: neuvector/controller
-    hash:
+    repository: suse/neuvector/controller
+    tag: 5.0.3
+    hash: sha256:dc88311c8af3a9c3cab2a3ea00a8556bb4e1ac2c7defeb841557f75cb74f86b3
   replicas: 3
   disruptionbudget: 0
   schedulerName:
@@ -206,8 +207,9 @@ enforcer:
   # If false, enforcer will not be installed
   enabled: true
   image:
-    repository: neuvector/enforcer
-    hash:
+    repository: suse/neuvector/enforcer
+    tag: 5.0.3
+    hash: sha256:49e5d82e311ee31c0621a81819d8746e1212b923b032f68f07558ee52ffcc4a5
   priorityClassName:
   tolerations:
     - effect: NoSchedule
@@ -224,8 +226,9 @@ manager:
   # If false, manager will not be installed
   enabled: true
   image:
-    repository: neuvector/manager
-    hash:
+    repository: suse/neuvector/manager
+    tag: 5.0.3
+    hash: sha256:eee3b7001135ff3caed6b5125bd0843ae528302f8bf31f584470013d060a5241
   priorityClassName:
   env:
     ssl: true
@@ -292,9 +295,9 @@ cve:
     enabled: true
     secure: false
     image:
-      repository: neuvector/updater
-      tag: latest
-      hash:
+      repository: suse/neuvector/updater
+      tag: 5
+      hash: sha256:802c37b0b756bd254dc9605436d5bd66009de4b4bfdb631762c356a3f608674c
     schedule: "0 0 * * *"
     priorityClassName:
     runAsUser:  # MUST be set for Rancher hardened cluster
@@ -308,9 +311,9 @@ cve:
         maxSurge: 1
         maxUnavailable: 0
     image:
-      repository: neuvector/scanner
-      tag: latest
-      hash:
+      repository: suse/neuvector/scanner
+      tag: 5
+      hash: sha256:b8850536d05a17b18ba3832b0c8b8390d4ab4580c974173b03937cc9d963fd00
     priorityClassName:
     resources: {}
       # limits:
@@ -341,7 +344,7 @@ k3s:
   runtimePath: /run/k3s/containerd/containerd.sock
 
 bottlerocket:
-  enabled: true
+  enabled: false
   runtimePath: /run/dockershim.sock
 
 containerd:


### PR DESCRIPTION
* ECR must have version-specific tags; 'latest' is a no-no
* If Bottlerocket is enabled, the controller fails to start on the default runtime (Docker in EKS K8s 1.21)